### PR TITLE
Browser support

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -489,7 +489,7 @@ const __bigFT = (function (){
 		if (getQueryParam('useCustomTimezone')) {
 			return getQueryParam('customTimezone');
 		} else {
-			const timezone = window.Intl === undefined ? '' : Intl.DateTimeFormat().resolvedOptions().timeZone;  // eslint-disable-line new-cap
+			const timezone = moment.tz.guess();
 
 			return timezone !== '' ? timezone : 'Europe/London';
 		}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "express-hbs": "^0.8.4",
     "jquery": "^2.1.4",
     "lodash": "^3.10.1",
-    "moment-timezone": "^0.4.1",
+    "moment-timezone": "^0.5.1",
     "morgan": "^1.6.1",
     "node-fetch": "^1.3.3",
     "npm-run-all": "^1.4.0",

--- a/server/views/index.hbs
+++ b/server/views/index.hbs
@@ -22,9 +22,9 @@
 		{{> sentry }}
 	{{/if}}
 
-	<script src="http://build.origami.ft.com/v2/bundles/js?modules=o-errors@^3.3.0"></script>
-	<script src="//polyfill.webservices.ft.com/v2/polyfill.min.js?features=fetch,promise,Array.prototype.find|always,Intl,Array.prototype.includes"></script>
-	<script src="/static/snap-svg.min.js"></script>
+	<script type="text/javascript" src="http://build.origami.ft.com/v2/bundles/js?modules=o-errors@^3.3.0"></script>
+	<script type="text/javascript" src="https://cdn.polyfill.io/v2/polyfill{{#if isProduction }}.min{{/if}}.js?features=default,fetch,promise,Array.prototype.find|always,Array.prototype.includes"></script>
+	<script type="text/javascript" src="/static/snap-svg.min.js"></script>
 
 
 </head>
@@ -79,7 +79,7 @@
 	{{!--<!--
 		Load LAB.js (Loading And Blocking JavaScript) to download the JS files asynchronously, ensuring execution order is kept.
 	-->--}}
-	<script src='https://cdnjs.cloudflare.com/ajax/libs/labjs/2.0.3/LAB.min.js'></script>
+	<script type="text/javascript" src='https://cdnjs.cloudflare.com/ajax/libs/labjs/2.0.3/LAB.min.js'></script>
 
 	{{!--<!--
 		Load main JavaScript bundle (asynchronously, to make sure it's non-blocking).


### PR DESCRIPTION
Drop Intl due to bug in polyfill service, replace with updated moment-timezone apply type to script tags for IE's sake, add default polyfills to get basic IE support

Should now work on:

Safari, IE10, IE11
